### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release theme
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout theme
+        uses: actions/checkout@v4
+
+      - name: Release .theme.css
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "*.theme.css"
+          makeLatest: true
+          generateReleaseNotes: true


### PR DESCRIPTION
A minor convenience for your theme - this release workflow automatically generates a release containing the `.theme.css` file when you push a tag starting with `v` (eg. `v1.3.6`).

- To create a tag locally: `git tag v1.3.6`
- To push a tag to origin: `git push origin v1.3.6`

If you make a mistake and want to delete a tag (this also destroys the release):
- Delete on origin: `git push origin --delete v1.3.6`
- Then delete locally: `git tag -d v1.3.6`

I've demonstrated this usage by pushing `vTest` on my fork: https://github.com/MiniDiscordThemes/Radion-BD-Theme/releases
